### PR TITLE
Add provider=aws.route53 to data.aws_route53_zone

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -5,6 +5,8 @@ locals {
 data "aws_region" "current" {}
 
 data "aws_route53_zone" "default" {
+  provider = aws.route53
+
   name = var.domain
 }
 


### PR DESCRIPTION
Without specifying the provider the data resource uses the default provider settings which is wrong.

Signed-off-by: Stephen Hoekstra <shoekstra@schubergphilis.com>
