### PR TITLE
Enable DMARC on the email domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Terraform module to configure SES.
 | Name | Type |
 |------|------|
 | [aws_route53_record.dkim](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_route53_record.dmarc](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.domain_mx](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.domain_spf](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
 | [aws_route53_record.mail_from_mx](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |

--- a/dmarc.tf
+++ b/dmarc.tf
@@ -1,0 +1,9 @@
+resource "aws_route53_record" "dmarc" {
+  provider = aws.route53
+
+  name    = "_dmarc.${var.domain}"
+  records = ["v=DMARC1;p=reject;sp=reject"]
+  ttl     = 600
+  type    = "TXT"
+  zone_id = data.aws_route53_zone.default.zone_id
+}


### PR DESCRIPTION
Create a DMARC record to make sure emails sent actually comply with the set SPF and DKIM records.
More info: https://docs.aws.amazon.com/ses/latest/dg/send-email-authentication-dmarc.html

This policy is set to reject 100% of the email in case the SPF or DKIM does not match for its domain and subdomains (only in case they don't specify their own DMARC record).