### PR TITLE
Add optional ability to configure dmarc RUA and RUF destinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Terraform module to configure SES.
 
 | Name | Version |
 |------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
 
 ## Providers
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Terraform module to configure SES.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_dmarc"></a> [dmarc](#input\_dmarc) | (Optional) DMARC configuration | <pre>object({<br>    policy = optional(string, "v=DMARC1;p=reject;sp=reject")<br>    rua    = optional(string)<br>    ruf    = optional(string)<br>  })</pre> | n/a | yes |
 | <a name="input_domain"></a> [domain](#input\_domain) | Domain name | `string` | n/a | yes |
 | <a name="input_tags"></a> [tags](#input\_tags) | Map of tags to set on Terraform created resources | `map(string)` | n/a | yes |
 | <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | KMS key ARN used for encryption | `string` | `null` | no |

--- a/dmarc.tf
+++ b/dmarc.tf
@@ -1,9 +1,15 @@
 resource "aws_route53_record" "dmarc" {
+  count    = var.dmarc != null ? 1 : 0
   provider = aws.route53
 
   name    = "_dmarc.${var.domain}"
-  records = ["v=DMARC1;p=reject;sp=reject"]
   ttl     = 600
   type    = "TXT"
   zone_id = data.aws_route53_zone.default.zone_id
+
+  records = [join(";", compact([
+    var.dmarc.policy,
+    var.dmarc != null ? var.dmarc.rua != null ? "rua=${var.dmarc.rua}" : null : null,
+    var.dmarc != null ? var.dmarc.ruf != null ? "ruf=${var.dmarc.ruf}" : null : null,
+  ]))]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -3,6 +3,15 @@ variable "domain" {
   description = "Domain name"
 }
 
+variable "dmarc" {
+  type = object({
+    policy = optional(string, "v=DMARC1;p=reject;sp=reject")
+    rua    = optional(string)
+    ruf    = optional(string)
+  })
+  description = "(Optional) DMARC configuration"
+}
+
 variable "mail_from_domain" {
   type        = string
   default     = null

--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.14"
+  required_version = ">= 1.3.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
This will make it possible to configure a RUA or RUF email adres to send DMARC reports to.