### PR TITLE
fix: SMTP user requires ses:SendRawEmail permissions on arn:aws:ses:<REGION>:<ACCOUNT>:identity/<MAIL_TO_ADDRESS> in order to be able to send mail.

### DIFF
--- a/smtp_users.tf
+++ b/smtp_users.tf
@@ -18,7 +18,7 @@ module "smtp_users" {
 data "aws_iam_policy_document" "allow_iam_user_to_send_emails" {
   statement {
     actions   = ["ses:SendRawEmail"]
-    resources = [aws_ses_domain_identity.default.arn]
+    resources = [replace(aws_ses_domain_identity.default.arn, var.domain, "*")]
   }
 }
 


### PR DESCRIPTION
Signed-off-by: Stefan Wessels Beljaars <swesselsbeljaars@schubergphilis.com>
