### PR TITLE
feat!: Add region support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,20 +8,20 @@ Terraform module to configure SES.
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.9.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.9.0 |
-| <a name="provider_aws.route53"></a> [aws.route53](#provider\_aws.route53) | >= 4.9.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 6.0.0 |
+| <a name="provider_aws.route53"></a> [aws.route53](#provider\_aws.route53) | >= 6.0.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_smtp_users"></a> [smtp\_users](#module\_smtp\_users) | github.com/schubergphilis/terraform-aws-mcaf-user | v0.1.12 |
+| <a name="module_smtp_users"></a> [smtp\_users](#module\_smtp\_users) | schubergphilis/mcaf-user/aws | ~> 1.0.0 |
 
 ## Resources
 
@@ -51,9 +51,10 @@ Terraform module to configure SES.
 |------|-------------|------|---------|:--------:|
 | <a name="input_domain"></a> [domain](#input\_domain) | Domain name | `string` | n/a | yes |
 | <a name="input_create_spf_wildcard_record"></a> [create\_spf\_wildcard\_record](#input\_create\_spf\_wildcard\_record) | Set to true to create an additional wildcard SPF record that denies email from all subdomains | `bool` | `true` | no |
-| <a name="input_dmarc"></a> [dmarc](#input\_dmarc) | DMARC configuration | <pre>object({<br>    policy = optional(string, "v=DMARC1;p=reject;sp=reject")<br>    rua    = optional(string)<br>    ruf    = optional(string)<br>  })</pre> | <pre>{<br>  "policy": "v=DMARC1;p=reject;sp=reject"<br>}</pre> | no |
+| <a name="input_dmarc"></a> [dmarc](#input\_dmarc) | DMARC configuration | <pre>object({<br/>    policy = optional(string, "v=DMARC1;p=reject;sp=reject")<br/>    rua    = optional(string)<br/>    ruf    = optional(string)<br/>  })</pre> | <pre>{<br/>  "policy": "v=DMARC1;p=reject;sp=reject"<br/>}</pre> | no |
 | <a name="input_kms_key_id"></a> [kms\_key\_id](#input\_kms\_key\_id) | KMS key ARN used for encryption | `string` | `null` | no |
 | <a name="input_mail_from_domain"></a> [mail\_from\_domain](#input\_mail\_from\_domain) | Set a MAIL FROM domain (defaults to `mail.$domain`) | `string` | `null` | no |
+| <a name="input_region"></a> [region](#input\_region) | The AWS region where resources will be created; if omitted the default provider region is used | `string` | `null` | no |
 | <a name="input_smtp_users"></a> [smtp\_users](#input\_smtp\_users) | List of SMTP users allowed to send mail from this domain | `list(string)` | `[]` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Map of tags to set on Terraform created resources | `map(string)` | `null` | no |
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,9 @@
+# Upgrading Notes
+
+This document captures required refactoring on your part when upgrading to a module version that contains breaking changes.
+
+## Upgrading to v1.0.0
+
+### Key Changes
+
+- This module now requires a minimum AWS provider version of 6.0.

--- a/dkim.tf
+++ b/dkim.tf
@@ -1,4 +1,5 @@
 resource "aws_ses_domain_dkim" "default" {
+  region = var.region
   domain = aws_ses_domain_identity.default.domain
 }
 

--- a/examples/basic/terraform.tf
+++ b/examples/basic/terraform.tf
@@ -5,7 +5,7 @@ terraform {
     aws = {
       configuration_aliases = [aws, aws.route53]
       source                = "hashicorp/aws"
-      version               = ">= 4.9.0"
+      version               = ">= 6.0.0"
     }
   }
 }

--- a/examples/smtp_user/terraform.tf
+++ b/examples/smtp_user/terraform.tf
@@ -5,7 +5,7 @@ terraform {
     aws = {
       configuration_aliases = [aws, aws.route53]
       source                = "hashicorp/aws"
-      version               = ">= 4.9.0"
+      version               = ">= 6.0.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -12,10 +12,12 @@ data "aws_route53_zone" "default" {
 
 // Configure domain identity
 resource "aws_ses_domain_identity" "default" {
+  region = var.region
   domain = var.domain
 }
 
 resource "aws_ses_domain_identity_verification" "default" {
+  region     = var.region
   domain     = aws_ses_domain_identity.default.id
   depends_on = [aws_route53_record.ses_verification]
 }
@@ -40,7 +42,7 @@ resource "aws_route53_record" "mail_from_mx" {
   provider = aws.route53
 
   name    = aws_ses_domain_mail_from.default.mail_from_domain
-  records = [format("10 feedback-smtp.%s.amazonses.com", data.aws_region.current.name)]
+  records = [format("10 feedback-smtp.%s.amazonses.com", data.aws_region.current.region)]
   ttl     = "600"
   type    = "MX"
   zone_id = data.aws_route53_zone.default.zone_id
@@ -51,7 +53,7 @@ resource "aws_route53_record" "domain_mx" {
   provider = aws.route53
 
   name    = var.domain
-  records = [format("10 inbound-smtp.%s.amazonaws.com", data.aws_region.current.name)]
+  records = [format("10 inbound-smtp.%s.amazonaws.com", data.aws_region.current.region)]
   ttl     = 600
   type    = "MX"
   zone_id = data.aws_route53_zone.default.zone_id

--- a/smtp_users.tf
+++ b/smtp_users.tf
@@ -4,8 +4,9 @@ module "smtp_users" {
   for_each = toset(var.smtp_users)
 
   source  = "schubergphilis/mcaf-user/aws"
-  version = "~> 0.4.3"
+  version = "~> 1.0.0"
 
+  region                   = var.region
   name                     = "${each.key}@${var.domain}"
   create_policy            = true
   policy                   = data.aws_iam_policy_document.allow_iam_user_to_send_emails.json
@@ -27,6 +28,7 @@ resource "aws_secretsmanager_secret" "default" {
   #checkov:skip=CKV2_AWS_57: Not possible to enable secret rotation for this resource
   for_each = toset(var.smtp_users)
 
+  region     = var.region
   name       = "ses/${var.domain}/${each.key}"
   kms_key_id = var.kms_key_id
   tags       = var.tags
@@ -35,6 +37,7 @@ resource "aws_secretsmanager_secret" "default" {
 resource "aws_secretsmanager_secret_version" "default" {
   for_each = toset(var.smtp_users)
 
+  region    = var.region
   secret_id = aws_secretsmanager_secret.default[each.key].id
 
   secret_string = jsonencode({

--- a/terraform.tf
+++ b/terraform.tf
@@ -5,7 +5,7 @@ terraform {
     aws = {
       configuration_aliases = [aws, aws.route53]
       source                = "hashicorp/aws"
-      version               = ">= 4.9.0"
+      version               = ">= 6.0.0"
     }
   }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -31,6 +31,12 @@ variable "kms_key_id" {
   description = "KMS key ARN used for encryption"
 }
 
+variable "region" {
+  type        = string
+  default     = null
+  description = "The AWS region where resources will be created; if omitted the default provider region is used"
+}
+
 variable "smtp_users" {
   type        = list(string)
   default     = []


### PR DESCRIPTION
⚠️ This introduces a breaking change as it requires at least v6 of the AWS provider. ⚠️

## :hammer_and_wrench: Summary

Region configuration improvements:
- Added a new region variable in variables.tf to allow users to specify the AWS region for the resources. If omitted, the default provider region is used.
- Solves deprecation warnings for the `aws_region` data source which the user will receive when using AWS v6.
